### PR TITLE
fix/color names in cart

### DIFF
--- a/src/components/CartProduct/index.jsx
+++ b/src/components/CartProduct/index.jsx
@@ -19,9 +19,9 @@ export default function CartProduct({ product }) {
   useEffect(() => {
     getColorName(color)
       .then((res) => {
-        setColorName(res.data?.colors[0].name);
+        setColorName(res.data.colors[0].name);
       });
-  }, []);
+  }, [color]);
 
   const firstImage = productImages.find((img) => img.perspective === 'front');
   const { cart, setCart } = useContext(CartContext);


### PR DESCRIPTION
Um problema que existe no carrinho é que ao deletar um item de uma posição, o item que fica em baixo passa para a posição do deletado e recebe a cor do produto anterior.

Para cada remoção no carrinho, a cor do item deve ser re setada.